### PR TITLE
Fixed issue when using default parameters value from env.json

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -177,18 +177,15 @@ fs
         .then(
           environment =>
             options.default
-              ? {
-                  prompt: options =>
-                    Promise.resolve(
-                      options.reduce(
+              ? Promise.resolve(
+                    environment.reduce(
                         (acc, option) => ({
                           ...acc,
-                          [option.name]: option.default
+                          [option.name]: option.defaultOption
                         }),
                         {}
                       )
                     )
-                }
               : Inquirer.prompt(
                   environment.map(({ name, defaultOption, sensitive }) => ({
                     type: sensitive ? "password" : "input",


### PR DESCRIPTION
When using envup with option "--default", it appears that the resulting .env file only contains :

```
prompt=function prompt(options) {
          return Promise.resolve(options.reduce(function (acc, option) {
            return _extends({}, acc, _defineProperty({}, option.name, option.defaultOption));
          }, {}));
 }
```
and not the "content" of env.json 